### PR TITLE
reference Software::License in Pod

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -16,6 +16,10 @@ Or use a different directory and the FreeBSD license:
 
 David Farrell L<PerlTricks.com|http://perltricks.com>
 
+=head2 SEE ALSO
+
+L<Software::License>
+
 =head2 LICENSE
 
 FreeBSD, see LICENSE


### PR DESCRIPTION
make it more clear where the magic strings are for the different licenses